### PR TITLE
Update DiawiUploader.java

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/diawi/DiawiUploader.java
+++ b/src/main/java/org/jenkinsci/plugins/diawi/DiawiUploader.java
@@ -107,7 +107,7 @@ public class DiawiUploader extends hudson.tasks.Builder implements SimpleBuildSt
 
                 DiawiRequest.DiawiJobStatus S = job.getStatus(token, proxyHost, proxyPort, proxyProtocol);
 
-                int max_trials = 30;
+                int max_trials = 3000;
                 int i = 0;
 
                 while (S.status == 2001 && i < max_trials) {


### PR DESCRIPTION
These changes will allow succesfully upload to the DIAWI, because 2001 code means processing, and these processing can take up to 1 minute, this is why we need more time to get the DIAWI link.